### PR TITLE
Build Fastify Backend

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,26 @@
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      globals: {
+        process: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      'no-unused-vars': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+];

--- a/backend/src/routes/neo.ts
+++ b/backend/src/routes/neo.ts
@@ -1,0 +1,74 @@
+import type { FastifyInstance } from "fastify";
+import axios from "axios";
+import "dotenv/config";
+import type {
+  NasaApiResponse,
+  FormattedNearEarthObject,
+} from "../types/nasa.js";
+import { formatAsteroid } from "../utils/formatAsteroid.js";
+
+const NASA_BASE_URL = "https://api.nasa.gov/neo/rest/v1";
+const API_KEY = process.env.NASA_API_KEY || "DEMO_KEY";
+
+export async function nearEathObjectsRoute(
+  fastify: FastifyInstance,
+): Promise<void> {
+  fastify.get<{
+    Querystring: {
+      start_date: string;
+      end_date?: string;
+    };
+  }>(
+    "/neo",
+    async (req, res) => {
+      try {
+        const { start_date, end_date } = req.query;
+        const endDate = end_date || start_date;
+
+        const response = await axios.get<NasaApiResponse>(
+          `${NASA_BASE_URL}/feed`,
+          {
+            params: {
+              start_date,
+              end_date: endDate,
+              api_key: API_KEY,
+            },
+            timeout: 10000,
+          },
+        );
+
+        const allObjects: FormattedNearEarthObject[] = Object.entries(
+          response.data.near_earth_objects,
+        ).flatMap(([date, asteroids]) =>
+          (asteroids as any[]).map((asteroid) => ({
+            ...formatAsteroid(asteroid),
+            approach_date: date,
+          })),
+        );
+
+        return {
+          start_date,
+          end_date: endDate,
+          count: allObjects.length,
+          objects: allObjects,
+        };
+      } catch (error) {
+        fastify.log.error("NASA API Error:", error as any);
+
+        if (axios.isAxiosError(error)) {
+          if (error.response?.status === 403) {
+            await res.status(403).send({
+              error: "NASA API key invalid or rate limit exceeded",
+            });
+
+            return;
+          }
+        }
+
+        await res.status(500).send({
+          error: "Failed to fetch NASA data",
+        });
+      }
+    },
+  );
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,26 @@
+import Fastify from 'fastify';
+import cors from '@fastify/cors';
+import { nearEathObjectsRoute } from './routes/neo.js';
+
+const fastify = Fastify({
+  logger: true
+});
+
+await fastify.register(cors, {
+  origin: process.env.NODE_ENV === 'production' ? false : ['http://localhost:3001']
+});
+
+await fastify.register(nearEathObjectsRoute, { prefix: '/api' });
+
+const start = async (): Promise<void> => {
+  try {
+    const port = Number(process.env.PORT) || 3001;
+    await fastify.listen({ port, host: '0.0.0.0' });
+    console.log(`Server running on http://localhost:${port}`);
+  } catch (err) {
+    fastify.log.error(err);
+    process.exit(1);
+  }
+};
+
+await start();

--- a/backend/src/types/nasa.ts
+++ b/backend/src/types/nasa.ts
@@ -1,0 +1,65 @@
+export interface NearEarthObject {
+  id: string;
+  neo_reference_id: string;
+  name: string;
+  nasa_jpl_url: string;
+  absolute_magnitude_h: number;
+  estimated_diameter: {
+    kilometers: {
+      estimated_diameter_min: number;
+      estimated_diameter_max: number;
+    };
+    meters: {
+      estimated_diameter_min: number;
+      estimated_diameter_max: number;
+    };
+    miles: {
+      estimated_diameter_min: number;
+      estimated_diameter_max: number;
+    };
+    feet: {
+      estimated_diameter_min: number;
+      estimated_diameter_max: number;
+    };
+  };
+  is_potentially_hazardous_asteroid: boolean;
+  close_approach_data: Array<{
+    close_approach_date: string;
+    close_approach_date_full: string;
+    epoch_date_close_approach: number;
+    relative_velocity: {
+      kilometers_per_second: string;
+      kilometers_per_hour: string;
+      miles_per_hour: string;
+    };
+    miss_distance: {
+      astronomical: string;
+      lunar: string;
+      kilometers: string;
+      miles: string;
+    };
+    orbiting_body: string;
+  }>;
+  is_sentry_object: boolean;
+}
+
+export interface NasaApiResponse {
+  links: {
+    next?: string;
+    prev?: string;
+    self: string;
+  };
+  element_count: number;
+  near_earth_objects: {
+    [date: string]: NearEarthObject[];
+  };
+}
+
+export interface FormattedNearEarthObject {
+  id: string;
+  name: string;
+  size: number;
+  distance: number;
+  velocity: number;
+  is_potentially_hazardous: boolean;
+}

--- a/backend/src/utils/formatAsteroid.ts
+++ b/backend/src/utils/formatAsteroid.ts
@@ -1,0 +1,19 @@
+import type { NearEarthObject, FormattedNearEarthObject } from "../types/nasa.js";
+
+export const formatAsteroid = (
+  asteroid: NearEarthObject
+): FormattedNearEarthObject => {
+  const closeApproach = asteroid.close_approach_data[0];
+
+  return {
+    id: asteroid.id,
+    name: asteroid.name.replace(/[()]/g, ""),
+    size:
+      (asteroid.estimated_diameter.miles.estimated_diameter_min +
+        asteroid.estimated_diameter.miles.estimated_diameter_max) /
+      2,
+    distance: closeApproach ? parseFloat(closeApproach.miss_distance.miles) : 0,
+    velocity: closeApproach ? parseFloat(closeApproach.relative_velocity.miles_per_hour) : 0,
+    is_potentially_hazardous: asteroid.is_potentially_hazardous_asteroid,
+  };
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,11 +9,10 @@
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
-    "types": [],
+
     // For nodejs:
-    // "lib": ["esnext"],
-    // "types": ["node"],
-    // and npm install -D @types/node
+    "lib": ["esnext"],
+    "types": ["node"],
 
     // Other Outputs
     "sourceMap": true,


### PR DESCRIPTION
## Summary:
- Setup Fastify `server.ts`
- Build `api/neo` route to fetch data from NASA NEO API - `https://api.nasa.gov/neo/rest/v1/feed?start_date=START_DATE&end_date=END_DATE&api_key=API_KEY`
- Format the NASA NEO API to include **_only_** the data needed on the frontend
- Add types for the request/response

The route can be tested locally: http://localhost:3001/api/neo?sort=size&start_date=2025-08-29&end_date=2025-08-30