### PR TITLE
Add Swagger documentation

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,5 +1,7 @@
 import Fastify from 'fastify';
 import cors from '@fastify/cors';
+import swagger from '@fastify/swagger';
+import swaggerUI from '@fastify/swagger-ui';
 import { nearEathObjectsRoute } from './routes/neo.js';
 
 const fastify = Fastify({
@@ -8,6 +10,28 @@ const fastify = Fastify({
 
 await fastify.register(cors, {
   origin: process.env.NODE_ENV === 'production' ? false : ['http://localhost:3001']
+});
+
+await fastify.register(swagger, {
+  swagger: {
+    info: {
+      title: 'NASA Dashboard',
+      description: 'API for fetching data from NASA\'s Near Earth Objects Web Service',
+      version: '1.0.0'
+    },
+    host: 'localhost:3001',
+    schemes: ['http'],
+    consumes: ['application/json'],
+    produces: ['application/json']
+  }
+});
+
+await fastify.register(swaggerUI, {
+  routePrefix: '/documentation',
+  uiConfig: {
+    docExpansion: 'full',
+    deepLinking: false
+  }
 });
 
 await fastify.register(nearEathObjectsRoute, { prefix: '/api' });


### PR DESCRIPTION
## Summary:
- Leverage the Fastify <> Swagger integration to creates a dedicated `/documentation` route for the `api/neo` endpoint
- If you navigate to [http://localhost:3001/documentation](http://localhost:3001/documentation), you'll find the Swagger docs (query params + API response codes) for `GET /api/neo`.